### PR TITLE
Domain wall example correction + H to mathcal{H} + groundstate to ground state

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -16,7 +16,7 @@ The executables are then available in the directory `build/examples`. Most examp
 <div class="grid cards" markdown>
 
 
--   :material-file-document:{ .lg .middle } __Groundstate energy__
+-   :material-file-document:{ .lg .middle } __Ground state energy__
 
     ---
 
@@ -25,7 +25,7 @@ The executables are then available in the directory `build/examples`. Most examp
     [source](examples/spinhalf_chain_e0.md) :simple-cplusplus: :simple-julia:
 
 
--  :material-file-document:{ .lg .middle } __Groundstate correlators__
+-  :material-file-document:{ .lg .middle } __Ground state correlators__
 
     ---
 
@@ -35,7 +35,7 @@ The executables are then available in the directory `build/examples`. Most examp
 
 
 
--  :material-file-document:{ .lg .middle } __Entanglement Entropy Groundstate__
+-  :material-file-document:{ .lg .middle } __Entanglement entropy ground state__
 
     ---
 
@@ -75,7 +75,7 @@ The executables are then available in the directory `build/examples`. Most examp
 
 <div class="grid cards" markdown>
 
--   :material-file-document:{ .lg .middle } __Specific Heat random t-J model__
+-   :material-file-document:{ .lg .middle } __Specific heat random t-J model__
 
     ---
 
@@ -85,7 +85,7 @@ The executables are then available in the directory `build/examples`. Most examp
 
     [source](examples/specific_heat_randomtj.md) :simple-cplusplus: :simple-julia:
 
--   :material-file-document:{ .lg .middle } __Specific Heat triangular t-J model__
+-   :material-file-document:{ .lg .middle } __Specific heat triangular t-J model__
 
     ---
 

--- a/docs/examples/spinhalf_chain_TOS.md
+++ b/docs/examples/spinhalf_chain_TOS.md
@@ -3,11 +3,9 @@
 **Author** Paul Ebert
 
 This example demonstrates how to set up a tower of states analysis with respect to translation symmetries using the example of a spin-$1/2$ chain
-
 $$
-    H = J \sum_{\langle i, j \rangle} \bm{S}_i \cdot \bm{S}_j,
+    \mathcal{H} = J \sum_{\langle i, j \rangle} \bm{S}_i \cdot \bm{S}_j,
 $$
-
 with periodic boundary conditions and $J>0$ for aniferromagnetic interactions.
 
 The code below demonstrates how the lowest energy levels for each value of the lattice momentum can be computed using the Lanczos algorithm.

--- a/docs/examples/spinhalf_chain_domain_wall_dynamics.md
+++ b/docs/examples/spinhalf_chain_domain_wall_dynamics.md
@@ -5,22 +5,20 @@
 This example demonstrates the time-evolution of quantum states in `XDiag` for the dynamics of a domain wall in the ferromagnetic spin-$1/2$ XXZ chain
 
 $$
-    H = \sum_{i=1}^{N-1} \Big(- J \bm{S}^z_i \cdot \bm{S}^z_{i+1} + \frac{\Delta}{2}\big( \bm{S}^+_i \cdot \bm{S}^-_{i+1} + \bm{S}^-_i \cdot \bm{S}^+_{i+1} \big) \Big),
+    \mathcal{H} = \sum_{i=1}^{N-1} \Big(- J \bm{S}^z_i \cdot \bm{S}^z_{i+1} + \frac{\Delta}{2}\big( \bm{S}^+_i \cdot \bm{S}^-_{i+1} + \bm{S}^-_i \cdot \bm{S}^+_{i+1} \big) \Big),
 $$
 
 where $0 < J$. Note that here we use open instead of periodic boundary conditions, allowing to have a single domain wall in the system.
 
 We choose as initial state the following eigenstate of the associated Ising chain (i.e. the model with only $S^zS^z$ interactions)
-
 $$
 \ket{\psi_0} = \ket{\uparrow\ldots\uparrow\downarrow\ldots\downarrow},
 $$ 
-
 having a domain wall in the middle of the chain. We expect the exchange terms in the XXZ Hamiltonian above to dissolve the domain wall over time as $\ket{\psi_0}$ is not an eigenstate of the XXZ chain. This process may also be viewed as suddenly turning on exchange interactions in an Ising chain.
 
 The code below demonstrates how the the initial domain wall slowly dissolves. The following figure was created using the Julia version of the code, which includes a plotting command:
 
-![Dynamics of a domain wall](../img/spinhalf_chain_domain_wall_dynamics.png){ align=center }
+![Dynamics of a domain wall](../img/spinhalf_chain_domain_wall_dynamics.png)
 
 
 === "C++"

--- a/docs/examples/spinhalf_chain_e0.md
+++ b/docs/examples/spinhalf_chain_e0.md
@@ -1,4 +1,4 @@
-# Groundstate energy
+# Ground state energy
 
 **Author:** Alexander Wietek
 
@@ -6,7 +6,7 @@ We compute the ground state energy of a spin S = 1/2 Heisenberg
 chain,
 
 $$
-    H = \sum_{\langle i, j \rangle} \bm{S}_i \cdot \bm{S}_j 
+    \mathcal{H} = \sum_{\langle i, j \rangle} \bm{S}_i \cdot \bm{S}_j 
 $$
 
 without using translational symmetries. This minimal example shows how

--- a/docs/examples/spinhalf_chain_gs_corr_symmetries.md
+++ b/docs/examples/spinhalf_chain_gs_corr_symmetries.md
@@ -5,7 +5,7 @@
 This example demonstrates how ground state expectation values can be computed for the spin-$\frac{1}{2}$ XXX antiferromagnetic chain
 
 $$
-    H = \sum_{\langle i, j \rangle} \bm{S}_i \cdot \bm{S}_j = \sum_{\langle i, j \rangle} (S^x_i S^x_j + S^y_i S^y_j + S^z_i S^z_j)
+    \mathcal{H} = \sum_{\langle i, j \rangle} \bm{S}_i \cdot \bm{S}_j = \sum_{\langle i, j \rangle} (S^x_i S^x_j + S^y_i S^y_j + S^z_i S^z_j)
 $$
 
 with periodic boundary conditions. The Hamiltonian is invariant under translations and decomposes into $N$ irreducible representations (irreps) labelled by lattice momentum $2\pi/N \times k$ where $k=0, 1, \ldots, N-1$. The Lanczos algorithm is run on all momentum sub-blocks, effectively exchanging a longer runtime for less memory consumption. An important caveat when working with representations is that the operators inside expectation values must be symmetrized with respect to the symmetry group.

--- a/docs/examples/spinhalf_chain_level_statistics.md
+++ b/docs/examples/spinhalf_chain_level_statistics.md
@@ -8,28 +8,28 @@ The term *level statistic* refers to the probability distribution $P(s)$ where t
 Since this is the standard procedure, we will assume that $P(s)$ is the distribution of the normalized energy differences below instead of writing $P(\tilde{s})$.
 
 It is well established that for integrable systems (i.e. those with conserved quantities) the level statistic is a Poissonian
-
-$$P_{\mathrm{Poiss}}(s) = \exp(-s)$$
-
+$$
+	P_{\mathrm{Poiss}}(s) = \exp(-s)
+$$
 whereas the so-called Wigner-Dyson distribution emerges for non-integrable systems
-
-$$P_{\mathrm{WD}}(s) = \frac{\pi s}{2} \exp(- \pi s^2/4).$$
-
+$$
+	P_{\mathrm{WD}}(s) = \frac{\pi s}{2} \exp(- \pi s^2/4).
+$$
 Intuitively speaking, this is because having a system with symmetries and associated conserved quantities leads to degeneracies that contribute to seeing $s=0$ very often such that $P_{\mathrm{Pois}}(0) > 0$. On the contrary, the energy levels of non-integrable systems are approximately randomly distributed (especially in the bulk of the spectrum), giving a distribution satisfying $P_{\mathrm{WD}}(0) = 0$.
 
 To showcase this, we inspect two spin-$1/2$ Hamiltonians on a chain, one being the integrable XXZ model
 
 $$
-    H_{\mathrm{i}} = \sum_{\langle i, j \rangle} \Big(J \bm{S}^z_i \cdot \bm{S}^z_j + \frac{\Delta}{2}\big( \bm{S}^+_i \cdot \bm{S}^-_j + \bm{S}^-_i \cdot \bm{S}^+_j \big) \Big)
+\mathcal{H}_{\mathrm{i}} = \sum_{\langle i, j \rangle} \Big(J \bm{S}^z_i \cdot \bm{S}^z_j + \frac{\Delta}{2}\big( \bm{S}^+_i \cdot \bm{S}^-_j + \bm{S}^-_i \cdot \bm{S}^+_j \big) \Big),
 $$
 
 while the second merely adds a next-nearest-neighbor interaction
 
 $$
-    H_{\mathrm{ni}} = H_{\mathrm{i}} + \sum_{<< i, j >>} J_2 \bm{S}^z_i \cdot \bm{S}^z_j
+    \mathcal{H}_{\mathrm{ni}} = H_{\mathrm{i}} + \sum_{<< i, j >>} J_2 \bm{S}^z_i \cdot \bm{S}^z_j
 $$
 
-and becomes "non-integrable". We must put "non-integrable" in quotes here, since strictly speaking both models are integrable. However, the $H_{\mathrm{ni}}$ system becomes non-integrable once the trivial spin-flip, mirror, and translation symmetries (we employ periodic boundary conditions) are removed. This is done by considering specific sectors of the total Hilbert space which is easily done in `XDiag`.
+and becomes "non-integrable". We must put "non-integrable" in quotes here, since strictly speaking both models are integrable. However, the $\mathcal{H}_{\mathrm{ni}}$ system becomes non-integrable once the trivial spin-flip, mirror, and translation symmetries (we employ periodic boundary conditions) are removed. This is done by considering specific sectors of the total Hilbert space which is easily done in `XDiag`.
 
 The code below demonstrates how the level statistics of these systems can be computed inside the sectors where all trivial symmetries are removed.
 The Julia version also contains a simple plotting method, leading to the following distribution of level statistics:

--- a/examples/spinhalf_chain_domain_wall_dynamics/main.cpp
+++ b/examples/spinhalf_chain_domain_wall_dynamics/main.cpp
@@ -25,17 +25,16 @@ try {
     std::vector<std::string> psi0_vec (N);
     for (int i=0; i<N/2; i++) {psi0_vec[i] = "Up";}
     for (int i=N/2; i<N; i++) {psi0_vec[i] = "Dn";}
-    auto psi0 = product_state(block, psi0_vec);
+    auto psi = product_state(block, psi0_vec);
 
     // time evolve psi0 and measure Sz expectation value
     double dt = 0.5;
     int Nt = 30;
     std::vector<std::vector<double> > Sz_expectation(Nt, std::vector<double>(N));
-    State psi_t;
     for (int t_step=0; t_step<Nt; t_step++){
-        psi_t = time_evolve(H, psi0, dt*t_step);
+        time_evolve_inplace(H, psi, dt);
         for (int i=0; i<N; i++){
-            Sz_expectation[t_step][i] = innerC(Op("Sz", {i}), psi_t).real(); // result must be real
+            Sz_expectation[t_step][i] = innerC(Op("Sz", {i}), psi).real(); // result must be real
         }
     }
 

--- a/examples/spinhalf_chain_domain_wall_dynamics/main.jl
+++ b/examples/spinhalf_chain_domain_wall_dynamics/main.jl
@@ -20,16 +20,16 @@ function main()
     # define initial state with domain wall
     block = Spinhalf(N)
     psi0_vec = vcat(repeat(["Up"], N÷2), repeat(["Dn"], N÷2))
-    psi0 = product_state(block, psi0_vec)
+    psi = product_state(block, psi0_vec)
 
     # time evolve and measure Sz expectation value
     dt = 0.5
     Nt = 30
     Sz_expectation = Matrix{Float64}(undef, Nt, N)
     for t_step in 1:Nt
-        psi_t = time_evolve(H, psi0, dt*t_step)
+        time_evolve_inplace(H, psi, dt)
         for i in 1:N
-            Sz_expectation[t_step, i] = real(inner(Op("Sz", [i]), psi_t))
+            Sz_expectation[t_step, i] = real(inner(Op("Sz", [i]), psi))
         end
     end
 


### PR DESCRIPTION
improved the time evolution in the domain wall example to be incremental (as discussed some time ago) + minor changes to ensure symbolic consistency with other examples