### PR TITLE
Real representations

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(XDIAG_TEST_SOURCES
   symmetries/test_fermi_sign.cpp
   symmetries/test_permutation.cpp
   symmetries/test_permutation_group.cpp
+  symmetries/test_representation.cpp
 
   operators/test_op.cpp
   operators/test_opsum.cpp

--- a/tests/symmetries/test_representation.cpp
+++ b/tests/symmetries/test_representation.cpp
@@ -4,15 +4,27 @@
 
 #include <xdiag/common.hpp>
 #include <xdiag/symmetries/representation.hpp>
+#include "../blocks/electron/testcases_electron.hpp"
 #include <xdiag/utils/xdiag_show.hpp>
 
 using namespace xdiag;
+using namespace arma;
+// using namespace std::complex_literals;
 
-TEST_CASE("symmetrize", "[representation]") try {
-  Log("Testing real representation");
-
-  
-
+TEST_CASE("representation", "[symmetries]") try {
+//   Log("Testing real representation construction");
+  for (int64_t n_sites = 3; n_sites < 8; ++n_sites){
+    auto irreps = testcases::electron::get_cyclic_group_irreps(n_sites);
+    for (auto irrep:irreps) {
+        auto chars_hc = arma::conj(irrep.characters().as<arma::cx_vec>());
+        auto irrep_hc = Representation(irrep.group(), arma::cx_vec(chars_hc));
+        XDIAG_SHOW(irrep);
+        XDIAG_SHOW(irrep_hc);
+        auto irrep_id = irrep * irrep_hc;
+        XDIAG_SHOW(irrep_id);
+        REQUIRE(irrep_id.isreal());        
+    }
+  }
 } catch (xdiag::Error e) {
     xdiag::error_trace(e);
 }

--- a/tests/symmetries/test_representation.cpp
+++ b/tests/symmetries/test_representation.cpp
@@ -1,0 +1,18 @@
+#include "../catch.hpp"
+
+#include <iostream>
+
+#include <xdiag/common.hpp>
+#include <xdiag/symmetries/representation.hpp>
+#include <xdiag/utils/xdiag_show.hpp>
+
+using namespace xdiag;
+
+TEST_CASE("symmetrize", "[representation]") try {
+  Log("Testing real representation");
+
+  
+
+} catch (xdiag::Error e) {
+    xdiag::error_trace(e);
+}

--- a/xdiag/operators/logic/qns.cpp
+++ b/xdiag/operators/logic/qns.cpp
@@ -277,26 +277,17 @@ representation(OpSum const &ops, PermutationGroup const &group) try {
   OpSum opso = order(ops);
   check_valid(opso);
   std::vector<complex> characters;
-  std::vector<double> characters_real;
   bool real = true;
   for (auto const &perm : group) {
     OpSum opsp = permute(opso, perm);
     std::optional<Scalar> factor = isapprox_multiple(opsp, opso);
     if (factor) {
       characters.push_back((*factor).as<complex>());
-      characters_real.push_back((*factor).real());
-      if (!(*factor).isreal()) {
-        real = false;
-      }
     } else {
       return std::nullopt;
     }
   }
-  if (real) {
-    return Representation(group, characters_real);
-  } else {
-    return Representation(group, characters);
-  }
+  return Representation(group, Vector(characters));
 } catch (Error const &e) {
   XDIAG_RETHROW(e);
 }

--- a/xdiag/symmetries/representation.cpp
+++ b/xdiag/symmetries/representation.cpp
@@ -8,8 +8,6 @@
 #include <iomanip>
 #include <numeric>
 
-#include "../utils/xdiag_show.hpp"
-
 namespace xdiag {
 
 template <typename T>

--- a/xdiag/symmetries/representation.cpp
+++ b/xdiag/symmetries/representation.cpp
@@ -8,6 +8,8 @@
 #include <iomanip>
 #include <numeric>
 
+#include "../utils/xdiag_show.hpp"
+
 namespace xdiag {
 
 template <typename T>
@@ -127,8 +129,15 @@ Representation multiply(Representation const &r1,
   }
   auto c1 = r1.characters().as<arma::cx_vec>();
   auto c2 = r2.characters().as<arma::cx_vec>();
-  return Representation(r1.group(), Vector(c1 % c2));
-} catch (Error const &e) {
+  auto c = arma::cx_vec(c1 % c2);
+  // If imaginary part is small, make it real
+  auto ni = arma::norm(arma::imag(c));
+  if (ni < 1e-12) { // tolerance for logic::qns is 1e-12
+    return Representation(r1.group(), arma::vec(arma::real(c)));
+  } else {
+  return Representation(r1.group(), c);
+  }
+  } catch (Error const &e) {
   XDIAG_RETHROW(e);
 }
 

--- a/xdiag/symmetries/representation.cpp
+++ b/xdiag/symmetries/representation.cpp
@@ -125,18 +125,9 @@ Representation multiply(Representation const &r1,
     XDIAG_THROW(
         "The two given representations are not defined for the same group.");
   }
-
-  if (isreal(r1) && isreal(r2)) {
-    auto c1 = r1.characters().as<arma::vec>();
-    auto c2 = r2.characters().as<arma::vec>();
-    return Representation(
-        r1.group(),
-        arma::vec(c1 % c2)); // % means element wise multiplication in armadillo
-  } else {
-    auto c1 = r1.characters().as<arma::cx_vec>();
-    auto c2 = r2.characters().as<arma::cx_vec>();
-    return Representation(r1.group(), arma::cx_vec(c1 % c2));
-  }
+  auto c1 = r1.characters().as<arma::cx_vec>();
+  auto c2 = r2.characters().as<arma::cx_vec>();
+  return Representation(r1.group(), Vector(c1 % c2));
 } catch (Error const &e) {
   XDIAG_RETHROW(e);
 }


### PR DESCRIPTION
Changed the constructors for representations. made the Vector constructor check for realness instead of arma::cx_vec; updated operator::logic::qns to default to the same Vector constructor.

Hopefully, this will fix the inconsistency noted in issue #60.