### PR TITLE
0.5.0 compatibility of three examples checked and expected output added

### DIFF
--- a/examples/spinhalf_chain_domain_wall_dynamics/main.cpp
+++ b/examples/spinhalf_chain_domain_wall_dynamics/main.cpp
@@ -40,7 +40,32 @@ try {
 
     // do something here with Sz_expectation (see Julia version for plotting routine)
 
+    // Have some dummy output here to check that it works
+    Log("Computation of Sz expectation value over time successful!");
+    Log("First 10 entries of Sz_expectation at the final time step:");
+    for (int i=0; i<10; i++){
+        Log("{0}: {1}", i, Sz_expectation[Nt-1][i]);
+    }
+
     return 0;
 } catch(Error e){
     error_trace(e);
 }
+
+/*
+Expected output: ----------
+
+Computation of Sz expectation value over time successful!
+First 10 entries of Sz_expectation at the final time step:
+0: 0.4432301014161501
+1: 0.3949290171366084
+2: 0.26315340423182404
+3: 0.19962207952810862
+4: 0.19857671600477483
+5: 0.1273102824169581
+6: 0.06956175013570078
+7: 0.03915075630069064
+8: -0.039150756300690724
+9: -0.06956175013570076
+*/
+

--- a/examples/spinhalf_chain_domain_wall_dynamics/main.jl
+++ b/examples/spinhalf_chain_domain_wall_dynamics/main.jl
@@ -33,6 +33,13 @@ function main()
         end
     end
 
+    # have some dummy output here to check against the C++ version of the example
+    println("Computation of Sz expectation value over time successful!")
+    println("First 10 entries of Sz_expectation at the final time step:")
+    for i in 1:10
+        println("$(i-1): ", Sz_expectation[Nt, i])
+    end
+
     # plot Sz expectation value
     @show heatmap(
         Sz_expectation,
@@ -41,7 +48,27 @@ function main()
         ylabel="time step",
         title = "Sz expectation value over time")
     
+    return 0;
 end
 
 
 main()
+
+
+#=
+Expected output: ----------
+
+Computation of Sz expectation value over time successful!
+First 10 entries of Sz_expectation at the final time step:
+0: 0.4432301014161557
+1: 0.3949290171366142
+2: 0.26315340423182687
+3: 0.19962207952811017
+4: 0.19857671600477683
+5: 0.1273102824169592
+6: 0.06956175013570165
+7: 0.039150756300690974
+8: -0.039150756300690905
+9: -0.06956175013570176
+=#
+

--- a/examples/spinhalf_chain_gs_corr_symmetries/main.cpp
+++ b/examples/spinhalf_chain_gs_corr_symmetries/main.cpp
@@ -58,6 +58,17 @@ int main() try {
 
   Log("Ground state energy: {:.12f}", e0);
   Log("Ground state correlator: {:.12f}", corr);
+  Log("State vector length = {}", size(psi0));
+
 } catch (Error e) {
   error_trace(e);
 }
+
+/*
+Expected output: ------------
+
+Ground state energy: -6.263549533546
+Ground state correlator: 0.096017183872
+State vector length = 1162 
+*/
+

--- a/examples/spinhalf_chain_gs_corr_symmetries/main.jl
+++ b/examples/spinhalf_chain_gs_corr_symmetries/main.jl
@@ -51,6 +51,15 @@ end
 
 main()
 
+#=
+Expected output: -------------
+
+Ground state energy: -6.2635495335462625
+Ground state correlator: 0.09601718387180613
+State vector length = 1162
+=#
+
+
 
 
 

--- a/examples/spinhalf_chain_level_statistics/main.cpp
+++ b/examples/spinhalf_chain_level_statistics/main.cpp
@@ -95,10 +95,43 @@ int main() try {
     std::vector<double> H_ni_statistics = compute_level_statistics(N, H_ni); 
 
     // do something with H_i_statistics and H_ni_statistics here (Julia version has a plotting routine)
+    
+    
+    // provide at least some output for this example
+    Log("Computation of level statistics successful!");
+    Log("First 5 entries for integrable system:");
+    for (int i=0; i<5; i++){
+        Log("{0}: {1}", i, H_i_statistics[i]);
+    }
+    Log("First 5 entries for non-integrable system:");
+    for (int i=0; i<5; i++){
+        Log("{0}: {1}", i, H_ni_statistics[i]);
+    }
+    Log("Check out the julia version of this example for a plotting routine of the level statistics! :)");
+
     return 0;
 
 } catch(Error e) {
     error_trace(e);
 }
+
+/*
+Expected output: ------------
+
+Computation of level statistics successful!
+First 5 entries for integrable system:
+0: 1.0292780071656977
+1: 0.04419530412289801
+2: 2.061467789167692
+3: 1.145698958627123
+4: 0.287886568633884
+First 5 entries for non-integrable system:
+0: 0.9950431011993061
+1: 0.5971502796198537
+2: 1.6884095111146158
+3: 0.1771094588797689
+4: 1.62995376934063
+Check out the julia version of this example for a plotting routine of the level statistics! :)
+*/
 
 

--- a/examples/spinhalf_chain_level_statistics/main.jl
+++ b/examples/spinhalf_chain_level_statistics/main.jl
@@ -34,6 +34,18 @@ function main()
     H_i_statistics = compute_level_statistics(N, H_i)
     H_ni_statistics = compute_level_statistics(N, H_ni)
 
+    # provide some output to compare against C++ version of this example
+    println("Computation of level statistics successful!")
+    println("First 5 entries for integrable system:")
+    for i in 1:5
+        println("$(i): $(H_i_statistics[i])")
+    end
+    println("First 5 entries for non-integrable system:")
+    for i in 1:5
+        println("$(i): $(H_ni_statistics[i])")
+    end
+
+
     # optional plot of histograms (only in Julia version!)
     plot_histograms(H_i_statistics, H_ni_statistics)
 end
@@ -56,7 +68,7 @@ function compute_level_statistics(N::Int, H::OpSum) :: Vector{Float64}
 
     # find its eigenspectrum
     Hmat = matrix(H, block)
-    eigenvalues = eigvals(Hermitian(Hmat))
+    eigenvalues = LinearAlgebra.eigvals(Hermitian(Hmat))
 
     # compute level statistics (taking only inner most half of spectrum)
     N_levels = size(block)
@@ -116,6 +128,24 @@ function Poisson_func(s::Float64) :: Float64
 end
 
 
-
-
 main()
+
+
+#=
+Expected output: -------------
+
+Computation of level statistics successful!
+First 5 entries for integrable system:
+1: 1.029278007162844
+2: 0.044195304122597784
+3: 2.0614677891688875
+4: 1.1456989586253195
+5: 0.2878865686346336
+First 5 entries for non-integrable system:
+1: 0.9950431011987169
+2: 0.5971502796192641
+3: 1.6884095111147648
+4: 0.17710945887888385
+5: 1.6299537693400414
+=#
+


### PR DESCRIPTION
The three examples that were modified run fine under 0.5.0. I just added additional print statements such that the outcome of the C++/julia computation can be checked against the expected result (given via comments at the end of the file) and against the other julia/C++ version of the code, respectively. 