### PR TITLE
Permutation symmetry error throwing behavior

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y clang llvm libhdf5-dev libblas-dev liblapack-dev
       - name: build (instrumented)
         run: |
-          cmake -S . -B build-cov -DCMAKE_BUILD_TYPE=Debug -DXDIAG_COVERAGE=ON -DBUILD_TESTING=ON
+          cmake -S . -B build-cov -DCMAKE_BUILD_TYPE=RelWithDebInfo -DXDIAG_COVERAGE=ON -DBUILD_TESTING=ON
           cmake --build build-cov --target tests -j$(nproc)
       - name: run tests
         run: LLVM_PROFILE_FILE=tests.profraw ./build-cov/tests/tests

--- a/.github/workflows/intelmpi.yml
+++ b/.github/workflows/intelmpi.yml
@@ -14,14 +14,20 @@ jobs:
 
     steps:
     - name: Intel Apt repository
-      timeout-minutes: 1
+      # Refreshing the Intel index plus every Ubuntu mirror regularly needs more
+      # than a minute on a loaded runner, which is what made this step fail at
+      # random. apt-key is deprecated and absent from newer Ubuntu, so the key
+      # goes into a keyring referenced by signed-by instead.
+      timeout-minutes: 5
       run: |
-        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        wget --tries=3 --timeout=30 -O GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB \
+          https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo gpg --dearmor --yes -o /usr/share/keyrings/oneapi-archive-keyring.gpg \
+          GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update
-        
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update -o Acquire::Retries=3
+
     - name: Install Intel oneAPI compilers
       timeout-minutes: 5
       run: sudo apt-get install intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp 

--- a/.github/workflows/intelmpi.yml
+++ b/.github/workflows/intelmpi.yml
@@ -26,7 +26,17 @@ jobs:
           GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update -o Acquire::Retries=3
+        # Refresh the Intel index only. A full update also polls
+        # azure.archive.ubuntu.com, the runner's default Ubuntu mirror, which
+        # stalls often enough to hang this step past any timeout - that, not the
+        # Intel repository, is what makes this job fail at random. The runner
+        # image already carries the Ubuntu package lists needed to resolve the
+        # dependencies of the oneAPI packages.
+        sudo apt-get update \
+          -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" \
+          -o Dir::Etc::sourceparts="-" \
+          -o APT::Get::List-Cleanup="0" \
+          -o Acquire::http::Timeout=20
 
     - name: Install Intel oneAPI compilers
       timeout-minutes: 5

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(XDIAG_TEST_SOURCES
 
   blocks/test_print_block.cpp
   blocks/test_index.cpp
+  blocks/test_blocks_match.cpp
 
   blocks/spinhalf/test_spinhalf_strategies.cpp
   blocks/spinhalf/test_spinhalf.cpp

--- a/tests/algebra/test_quantum_numbers.cpp
+++ b/tests/algebra/test_quantum_numbers.cpp
@@ -126,10 +126,9 @@ static void test_charge_rep(std::string const &name, int64_t nsites,
       OpSum ops =
           random_charge_opsum(nsites, target, rl, neutrals, n_neutral, 3, gen);
       for (auto const &a : actions) {
-        std::optional<Representation> rep =
+        Representation rep =
             algebra::representation(ops, Representation(a, 0), alg);
-        REQUIRE(rep);
-        REQUIRE(rep->charge() == target.at(a));
+        REQUIRE(rep.charge() == target.at(a));
       }
 
       // Test 2: representation(op1 * op2) == representation(op1) *
@@ -145,11 +144,8 @@ static void test_charge_rep(std::string const &name, int64_t nsites,
         auto r1 = algebra::representation(o1, Representation(a, 0), alg);
         auto r2 = algebra::representation(o2, Representation(a, 0), alg);
         auto rp = algebra::representation(prod, Representation(a, 0), alg);
-        REQUIRE(r1);
-        REQUIRE(r2);
-        REQUIRE(rp);
-        REQUIRE(isapprox(*rp, (*r1) * (*r2)));
-        REQUIRE(rp->charge() == t1.at(a) + t2.at(a));
+        REQUIRE(isapprox(rp, r1 * r2));
+        REQUIRE(rp.charge() == t1.at(a) + t2.at(a));
       }
     }
   }

--- a/tests/algebra/test_representation.cpp
+++ b/tests/algebra/test_representation.cpp
@@ -30,43 +30,40 @@ TEST_CASE("opsumrepresentation", "[algebra]") {
   // For a charge Representation the type names the action ("nup"/"ndn"/"np").
   // The charge passed in is ignored and recomputed from the OpSum. The algebra
   // only matters for "Matrix" Ops (via its local dimension d); d == 2 suffices.
-  auto nup = [](OpSum const &ops) -> std::optional<int64_t> {
-    std::optional<Representation> rep =
-        representation(ops, Representation("nup", 0), matrix_algebra(2, 2));
-    return rep ? std::optional<int64_t>(rep->charge()) : std::nullopt;
+  auto nup = [](OpSum const &ops) -> int64_t {
+    return representation(ops, Representation("nup", 0), matrix_algebra(2, 2))
+        .charge();
   };
-  auto ndn = [](OpSum const &ops) -> std::optional<int64_t> {
-    std::optional<Representation> rep =
-        representation(ops, Representation("ndn", 0), matrix_algebra(2, 2));
-    return rep ? std::optional<int64_t>(rep->charge()) : std::nullopt;
+  auto ndn = [](OpSum const &ops) -> int64_t {
+    return representation(ops, Representation("ndn", 0), matrix_algebra(2, 2))
+        .charge();
   };
 
   // The result is itself a charge Representation labelled by the action.
   {
-    std::optional<Representation> rep = representation(
+    Representation rep = representation(
         OpSum(Op("S+", 0)), Representation("nup", 999), matrix_algebra(2, 2));
-    REQUIRE(rep);
-    REQUIRE(rep->is_charge());
-    REQUIRE(rep->type() == "nup");
-    REQUIRE(rep->charge() == 1); // input charge 999 was ignored
+    REQUIRE(rep.is_charge());
+    REQUIRE(rep.type() == "nup");
+    REQUIRE(rep.charge() == 1); // input charge 999 was ignored
   }
 
-  REQUIRE(*nup(OpSum(Op("S+", 0))) == 1);
-  REQUIRE(*ndn(OpSum(Op("S+", 0))) == -1);
-  REQUIRE(*nup(OpSum(Op("S-", 0))) == -1);
-  REQUIRE(*ndn(OpSum(Op("S-", 0))) == 1);
+  REQUIRE(nup(OpSum(Op("S+", 0))) == 1);
+  REQUIRE(ndn(OpSum(Op("S+", 0))) == -1);
+  REQUIRE(nup(OpSum(Op("S-", 0))) == -1);
+  REQUIRE(ndn(OpSum(Op("S-", 0))) == 1);
 
-  REQUIRE(*nup(OpSum(Op("Cdagup", 0))) == 1);
-  REQUIRE(*ndn(OpSum(Op("Cdagup", 0))) == 0);
-  REQUIRE(*nup(OpSum(Op("Cup", 0))) == -1);
-  REQUIRE(*ndn(OpSum(Op("Cdagdn", 0))) == 1);
-  REQUIRE(*ndn(OpSum(Op("Cdn", 0))) == -1);
+  REQUIRE(nup(OpSum(Op("Cdagup", 0))) == 1);
+  REQUIRE(ndn(OpSum(Op("Cdagup", 0))) == 0);
+  REQUIRE(nup(OpSum(Op("Cup", 0))) == -1);
+  REQUIRE(ndn(OpSum(Op("Cdagdn", 0))) == 1);
+  REQUIRE(ndn(OpSum(Op("Cdn", 0))) == -1);
 
-  REQUIRE(*nup(OpSum(Op("SdotS", {0, 1}))) == 0);
-  REQUIRE(*nup(OpSum(Op("Sz", 0))) == 0);
+  REQUIRE(nup(OpSum(Op("SdotS", {0, 1}))) == 0);
+  REQUIRE(nup(OpSum(Op("Sz", 0))) == 0);
 
   // Different monomials carrying different charges -> no well-defined sector
-  REQUIRE(nup(OpSum(Op("S+", 0)) + OpSum(Op("Sz", 0))) == std::nullopt);
+  REQUIRE_THROWS_AS(nup(OpSum(Op("S+", 0)) + OpSum(Op("Sz", 0))), Error);
 
   // "Matrix" Ops: charge from the particle-number difference of nonzero entries
   mat sz({{0.5, 0.0}, {0.0, -0.5}});
@@ -76,12 +73,12 @@ TEST_CASE("opsumrepresentation", "[algebra]") {
   mat b = mat({{0., -0.5}, {0.5, 0.}});
   cx_mat sy(a, b);
 
-  REQUIRE(*nup(OpSum(Op("Matrix", 0, sz))) == 0);
-  REQUIRE(*nup(OpSum(Op("Matrix", 0, sp))) == 1);
-  REQUIRE(*nup(OpSum(Op("Matrix", 0, sm))) == -1);
-  REQUIRE(nup(OpSum(Op("Matrix", 0, sy))) == std::nullopt);
-  REQUIRE(*nup(OpSum(Op("Matrix", {0, 1}, mat(kron(sp, sp))))) == 2);
-  REQUIRE(*nup(OpSum(Op("Matrix", {0, 1}, mat(kron(sp, sm))))) == 0);
+  REQUIRE(nup(OpSum(Op("Matrix", 0, sz))) == 0);
+  REQUIRE(nup(OpSum(Op("Matrix", 0, sp))) == 1);
+  REQUIRE(nup(OpSum(Op("Matrix", 0, sm))) == -1);
+  REQUIRE_THROWS_AS(nup(OpSum(Op("Matrix", 0, sy))), Error);
+  REQUIRE(nup(OpSum(Op("Matrix", {0, 1}, mat(kron(sp, sp))))) == 2);
+  REQUIRE(nup(OpSum(Op("Matrix", {0, 1}, mat(kron(sp, sm))))) == 0);
 
   //
   // ===========================================================================
@@ -96,28 +93,25 @@ TEST_CASE("opsumrepresentation", "[algebra]") {
       Representation irrep = cyclic_group_irrep(nsites, k);
       OpSum ops = symmetrize(Op("Sz", 0), irrep);
 
-      std::optional<Representation> rep =
-          representation(ops, irrep, spin_algebra(nsites));
-      REQUIRE(rep);
-      REQUIRE(rep->is_permutation());
-      REQUIRE(isapprox(*rep, irrep));
+      Representation rep = representation(ops, irrep, spin_algebra(nsites));
+      REQUIRE(rep.is_permutation());
+      REQUIRE(isapprox(rep, irrep));
 
       // Only the GROUP of the input is used; its characters are ignored.
       // Passing the trivial irrep (same group, different characters)
       // recovers the same result.
-      std::optional<Representation> rep2 =
-          representation(ops, trivial, spin_algebra(nsites));
-      REQUIRE(rep2);
-      REQUIRE(isapprox(*rep2, irrep));
+      Representation rep2 = representation(ops, trivial, spin_algebra(nsites));
+      REQUIRE(isapprox(rep2, irrep));
     }
   }
 
-  // An OpSum that is not covariant under the group has no well-defined sector:
-  // a single-site Sz is not mapped to a multiple of itself by translations.
+  // An OpSum that is not covariant under the group has no well-defined sector
+  // and throws: a single-site Sz is not mapped to a multiple of itself by
+  // translations.
   {
-    std::optional<Representation> none = representation(
-        OpSum(Op("Sz", 0)), cyclic_group_irrep(4, 0), spin_algebra(4));
-    REQUIRE_FALSE(none);
+    REQUIRE_THROWS_AS(representation(OpSum(Op("Sz", 0)),
+                                     cyclic_group_irrep(4, 0), spin_algebra(4)),
+                      Error);
   }
 
   //
@@ -147,12 +141,11 @@ TEST_CASE("opsumrepresentation", "[algebra]") {
                      perm));
   }
 
-  // Symmetries under which the OpSum has no well-defined sector are dropped.
+  // A symmetry under which the OpSum has no well-defined sector throws.
   {
     OpSum mixed = OpSum(Op("S+", 0)) + OpSum(Op("Sz", 0)); // nup ill-defined
     RepresentationSet irreps({Representation("nup", 0)});
-    RepresentationSet result =
-        representations(mixed, irreps, matrix_algebra(1, 2));
-    REQUIRE(result.size() == 0);
+    REQUIRE_THROWS_AS(representations(mixed, irreps, matrix_algebra(1, 2)),
+                      Error);
   }
 }

--- a/tests/blocks/test_blocks_match.cpp
+++ b/tests/blocks/test_blocks_match.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Alexander Wietek <awietek@pks.mpg.de>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tests/catch.hpp>
+
+#include <xdiag/algebra/isapprox.hpp>
+#include <xdiag/blocks/blocks.hpp>
+#include <xdiag/blocks/spinhalf.hpp>
+#include <xdiag/kernels/matrix.hpp>
+#include <xdiag/kernels/sparse/coo_matrix.hpp>
+#include <xdiag/kernels/sparse/csc_matrix.hpp>
+#include <xdiag/kernels/sparse/csr_matrix.hpp>
+#include <xdiag/linalg/sparse_diag.hpp>
+#include <xdiag/operators/op.hpp>
+#include <xdiag/operators/opsum.hpp>
+#include <xdiag/states/apply.hpp>
+#include <xdiag/states/fill.hpp>
+#include <xdiag/states/random_state.hpp>
+#include <xdiag/states/state.hpp>
+#include <xdiag/symmetries/cyclic_group.hpp>
+#include <xdiag/utils/error.hpp>
+
+using namespace xdiag;
+
+// Regression test for github.com/awietek/xdiag/discussions/110: an OpSum which
+// does not commute with the symmetry group of the block it is diagonalized on
+// used to be applied silently, since the iterative solvers call the kernel-level
+// apply directly and thereby bypassed the blocks_match check that the
+// State-level apply performs. The resulting energies were meaningless (and not
+// even variational -- in the discussion they fell below the true ground state).
+TEST_CASE("blocks_match_symmetry", "[blocks]") {
+  int64_t nsites = 12;
+
+  // Heisenberg chain with periodic boundaries: invariant under translations.
+  OpSum ops;
+  for (int64_t i = 0; i < nsites; ++i) {
+    ops += Op("SdotS", {i, (i + 1) % nsites});
+  }
+
+  // Same, but with a single bond moved off the symmetry orbit. This is exactly
+  // the shape of the typo in the discussion: one bond of the lattice file
+  // connected the wrong pair of sites, so no translation maps the bond set onto
+  // itself any more.
+  OpSum ops_broken;
+  for (int64_t i = 0; i < nsites; ++i) {
+    if (i == 3) {
+      ops_broken += Op("SdotS", {i, (i + 2) % nsites});
+    } else {
+      ops_broken += Op("SdotS", {i, (i + 1) % nsites});
+    }
+  }
+
+  auto irrep = cyclic_group_irrep(nsites, 0);
+  auto block_sym = Spinhalf(nsites, irrep);
+  auto block_full = Spinhalf(nsites);
+
+  // The symmetric OpSum still works and agrees with the full Hilbert space.
+  {
+    double e0_sym = eigval0(ops, block_sym);
+    double e0_full = eigval0(ops, block_full);
+    REQUIRE(std::abs(e0_sym - e0_full) < 1e-8);
+  }
+
+  // The non-invariant OpSum must throw rather than return a number, on every
+  // route into the kernels: the iterative solvers, the dense matrix builders,
+  // and apply.
+  {
+    REQUIRE_THROWS_AS(eigval0(ops_broken, block_sym), Error);
+    REQUIRE_THROWS_AS(eig0(ops_broken, block_sym), Error);
+    REQUIRE_THROWS_AS(eigvals(ops_broken, block_sym, 1), Error);
+    REQUIRE_THROWS_AS(matrixC(ops_broken, block_sym, block_sym), Error);
+
+    auto v = State(block_sym);
+    fill(v, RandomState(42));
+    auto w = State(block_sym);
+    REQUIRE_THROWS_AS(apply(ops_broken, v, w), Error);
+  }
+
+  // The sparse route is checked when the matrix is assembled, so a CSR/CSC/COO
+  // matrix can never be built from a non-invariant OpSum on a symmetric block
+  // in the first place. Applying an already-assembled sparse matrix therefore
+  // needs no further check.
+  {
+    REQUIRE(csr_matrixC(ops, block_sym, block_sym).data.n_elem > 0);
+    REQUIRE_THROWS_AS(csr_matrixC(ops_broken, block_sym, block_sym), Error);
+    REQUIRE_THROWS_AS(csc_matrixC(ops_broken, block_sym, block_sym), Error);
+    REQUIRE_THROWS_AS(coo_matrixC(ops_broken, block_sym, block_sym), Error);
+    REQUIRE_THROWS_AS(csr_matrixC(ops_broken, block_sym), Error);
+  }
+
+  // Without symmetries the same OpSum is perfectly legitimate: nothing is being
+  // assumed about it, so no check may fire.
+  {
+    double e0 = eigval0(ops_broken, block_full);
+    REQUIRE(std::isfinite(e0));
+  }
+
+  // The check must also catch the "Matrix" Op spelling used in the discussion,
+  // where the two-site coupling is given as an explicit 4x4 matrix.
+  {
+    arma::cx_mat sx = {{complex(0, 0), complex(0.5, 0)},
+                       {complex(0.5, 0), complex(0, 0)}};
+    arma::cx_mat sy = {{complex(0, 0), complex(0, -0.5)},
+                       {complex(0, 0.5), complex(0, 0)}};
+    arma::cx_mat sz = {{complex(0.5, 0), complex(0, 0)},
+                       {complex(0, 0), complex(-0.5, 0)}};
+    arma::cx_mat pair =
+        arma::kron(sx, sx) + arma::kron(sy, sy) + arma::kron(sz, sz);
+
+    OpSum ops_mat, ops_mat_broken;
+    for (int64_t i = 0; i < nsites; ++i) {
+      ops_mat += Op("Matrix", {i, (i + 1) % nsites}, pair);
+      if (i == 3) {
+        ops_mat_broken += Op("Matrix", {i, (i + 2) % nsites}, pair);
+      } else {
+        ops_mat_broken += Op("Matrix", {i, (i + 1) % nsites}, pair);
+      }
+    }
+
+    REQUIRE(std::isfinite(eigval0(ops_mat, block_sym)));
+    REQUIRE_THROWS_AS(eigval0(ops_mat_broken, block_sym), Error);
+  }
+}

--- a/xdiag/algebra/representation.cpp
+++ b/xdiag/algebra/representation.cpp
@@ -190,6 +190,17 @@ Representation representation(OpSum const &ops, Representation const &irrep,
             "term:\n{}",
             g, to_string(group[g])));
       }
+
+      // lambda == 0 means the permuted OpSum vanishes, and since permutations
+      // are invertible ops itself is zero. The zero OpSum carries no character:
+      // every lambda satisfies permute(0) == lambda * 0. It is invariant under
+      // the whole group, so report the trivial representation -- reading a
+      // character off it would contradict the invariance the fast path above
+      // correctly detects.
+      if (lambda->as<complex>() == 0.0) {
+        return Representation(group, arma::vec(n, arma::fill::ones));
+      }
+
       chars[g] = lambda->as<complex>();
       if (!lambda->isreal()) {
         real = false;

--- a/xdiag/algebra/representation.cpp
+++ b/xdiag/algebra/representation.cpp
@@ -4,8 +4,10 @@
 
 #include "representation.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <map>
+#include <numeric>
 #include <set>
 #include <vector>
 
@@ -124,6 +126,34 @@ static std::optional<int64_t> opsum_charge(OpSum const &ops,
 }
 XDIAG_CATCH
 
+// Cheap sufficient test for permuted == ops. If ops is invariant under the
+// permutation, permuted holds the very same terms in a different order, which
+// sorting by monomial decides -- without any normal ordering, which is
+// essentially the entire cost of isapprox_multiple. Returning false merely
+// falls back to the general comparison, so this can never mask an asymmetry.
+static bool same_terms(OpSum const &ops, OpSum const &permuted) {
+  std::vector<Term> const &a = ops.terms();
+  std::vector<Term> const &b = permuted.terms();
+  if (a.size() != b.size()) {
+    return false;
+  }
+  std::vector<int64_t> ia(a.size()), ib(b.size());
+  std::iota(ia.begin(), ia.end(), 0);
+  std::iota(ib.begin(), ib.end(), 0);
+  std::sort(ia.begin(), ia.end(), [&](int64_t x, int64_t y) {
+    return a[x].monomial < a[y].monomial;
+  });
+  std::sort(ib.begin(), ib.end(), [&](int64_t x, int64_t y) {
+    return b[x].monomial < b[y].monomial;
+  });
+  for (int64_t i = 0; i < (int64_t)a.size(); ++i) {
+    if (!(a[ia[i]] == b[ib[i]])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // --- representation() -------------------------------------------------------
 
 // Determine the Representation that `ops` transforms under, with respect to the
@@ -146,6 +176,10 @@ Representation representation(OpSum const &ops, Representation const &irrep,
     bool real = true;
     for (int64_t g = 0; g < n; ++g) {
       OpSum permuted = permute(ops, group[g]);
+      if (same_terms(ops, permuted)) {
+        chars[g] = 1.0;
+        continue;
+      }
       std::optional<Scalar> lambda =
           isapprox_multiple(permuted, ops, algebra, tol, tol);
       if (!lambda) {

--- a/xdiag/algebra/representation.cpp
+++ b/xdiag/algebra/representation.cpp
@@ -131,12 +131,10 @@ XDIAG_CATCH
 // permutation Representation supplies the PermutationGroup whose action is
 // probed; a charge (U(1)) Representation supplies the action string via its
 // type. The charge/characters carried by `irrep` itself are ignored and
-// recomputed from `ops`. Returns std::nullopt if `ops` has no well-defined
-// sector under that symmetry.
-std::optional<Representation> representation(OpSum const &ops,
-                                             Representation const &irrep,
-                                             Algebra const &algebra,
-                                             double tol) try {
+// recomputed from `ops`. Throws if `ops` has no well-defined sector under the
+// symmetry, naming the offending group element resp. the unconserved charge.
+Representation representation(OpSum const &ops, Representation const &irrep,
+                              Algebra const &algebra, double tol) try {
   if (irrep.is_permutation()) {
     // `ops` transforms as a 1-D irrep iff every group element only rescales it.
     // The scalar lambda with permute(ops, g) == lambda * ops is the character
@@ -151,7 +149,12 @@ std::optional<Representation> representation(OpSum const &ops,
       std::optional<Scalar> lambda =
           isapprox_multiple(permuted, ops, algebra, tol, tol);
       if (!lambda) {
-        return std::nullopt;
+        XDIAG_THROW(fmt::format(
+            "The OpSum is not invariant under the given PermutationGroup: "
+            "element {} maps it onto a different operator. Please check that "
+            "this permutation maps every term of the OpSum onto another "
+            "term:\n{}",
+            g, to_string(group[g])));
       }
       chars[g] = lambda->as<complex>();
       if (!lambda->isreal()) {
@@ -168,7 +171,9 @@ std::optional<Representation> representation(OpSum const &ops,
     std::optional<int64_t> charge =
         opsum_charge(ops, irrep.type(), algebra.d, tol);
     if (!charge) {
-      return std::nullopt;
+      XDIAG_THROW(fmt::format("The OpSum does not conserve the charge \"{}\": "
+                              "its terms do not all carry the same charge.",
+                              irrep.type()));
     }
     return Representation(irrep.type(), *charge);
   }
@@ -176,18 +181,13 @@ std::optional<Representation> representation(OpSum const &ops,
 XDIAG_CATCH
 
 // Determine the Representation that `ops` transforms under for each symmetry in
-// `irreps`. Symmetries under which `ops` has no well-defined sector are dropped
-// from the result.
+// `irreps`. Throws if `ops` has no well-defined sector under one of them.
 RepresentationSet representations(OpSum const &ops,
                                   RepresentationSet const &irreps,
                                   Algebra const &algebra, double tol) try {
   std::vector<Representation> result;
   for (Representation const &irrep : irreps) {
-    std::optional<Representation> rep =
-        representation(ops, irrep, algebra, tol);
-    if (rep) {
-      result.push_back(*rep);
-    }
+    result.push_back(representation(ops, irrep, algebra, tol));
   }
   return RepresentationSet(result);
 }

--- a/xdiag/algebra/representation.hpp
+++ b/xdiag/algebra/representation.hpp
@@ -13,10 +13,9 @@
 
 namespace xdiag::algebra {
 
-std::optional<Representation> representation(OpSum const &ops,
-                                             Representation const &irrep,
-                                             Algebra const &algebra,
-                                             double tol = 1e-12);
+// Throws if ops has no well-defined sector under the symmetry of irrep.
+Representation representation(OpSum const &ops, Representation const &irrep,
+                              Algebra const &algebra, double tol = 1e-12);
 
 RepresentationSet representations(OpSum const &ops,
                                   RepresentationSet const &irreps,

--- a/xdiag/blocks/blocks.cpp
+++ b/xdiag/blocks/blocks.cpp
@@ -26,15 +26,6 @@ static RepresentationSet output_irreps(OpSum const &ops,
                                        algebra::Algebra const &algebra) try {
   RepresentationSet in = block_in.irreps();
   RepresentationSet shift = algebra::representations(ops, in, algebra);
-  for (Representation const &rep : in) {
-    if (!shift.has_type(rep.type())) {
-      XDIAG_THROW(fmt::format(
-          "Cannot determine output block: the OpSum has no well-defined "
-          "quantum number for the symmetry of type \"{}\" carried by the input "
-          "block.",
-          rep.type()));
-    }
-  }
   return in * shift;
 }
 XDIAG_CATCH
@@ -84,6 +75,16 @@ bool blocks_match(OpSum const &ops, Block const &block_in,
         }
       },
       block_in, block_out);
+}
+XDIAG_CATCH
+
+void check_blocks_match(OpSum const &ops, Block const &block_in,
+                        Block const &block_out) try {
+  if (!blocks_match(ops, block_in, block_out)) {
+    XDIAG_THROW("The OpSum maps the input block onto a different symmetry "
+                "sector than the output block. Please check the quantum "
+                "numbers of the output block.");
+  }
 }
 XDIAG_CATCH
 

--- a/xdiag/blocks/blocks.hpp
+++ b/xdiag/blocks/blocks.hpp
@@ -71,6 +71,15 @@ Block block(OpSum const &ops, Block const &block_in);
 bool blocks_match(OpSum const &ops, Block const &block_in,
                   Block const &block_out);
 
+// Throws unless blocks_match(ops, block_in, block_out). This is the
+// precondition of every apply / matrix kernel: unless it holds, block_out is
+// not the image of block_in under ops and the numbers a kernel produces are
+// meaningless. An OpSum which is not invariant under a symmetry group carried
+// by the blocks throws from within blocks_match, naming the offending group
+// element.
+void check_blocks_match(OpSum const &ops, Block const &block_in,
+                        Block const &block_out);
+
 template <typename T> struct is_distributed : std::false_type {};
 #ifdef XDIAG_DISTRIBUTED
 template <> struct is_distributed<SpinhalfDistributed> : std::true_type {};

--- a/xdiag/kernels/apply.cpp
+++ b/xdiag/kernels/apply.cpp
@@ -86,6 +86,8 @@ template <typename mat_t>
 static void apply_variant(OpSum const &ops, Block const &block_in,
                           mat_t const &vec_in, Block const &block_out,
                           mat_t &vec_out) try {
+  check_blocks_match(ops, block_in, block_out);
+
   // Layer 1: unwrap the Block variant (op_t is promoted to OpSum inside) and
   // forward to the block-generic apply_impl.
   utils::visit_same_type(

--- a/xdiag/kernels/matrix.cpp
+++ b/xdiag/kernels/matrix.cpp
@@ -79,6 +79,8 @@ XDIAG_CATCH
 template <typename coeff_t>
 void matrix(OpSum const &ops, Block const &block_in, Block const &block_out,
             coeff_t *mat) try {
+  check_blocks_match(ops, block_in, block_out);
+
   int64_t m = size(block_out);
   int64_t n = dim(block_in);
   std::fill_n(mat, m * n, coeff_t(0));
@@ -119,6 +121,8 @@ arma::mat matrix(op_t const &op, Block const &block_in,
                 "Consider using matrixC instead.");
   }
 
+  check_blocks_match(OpSum(op), block_in, block_out);
+
   int64_t m = size(block_out);
   int64_t n = dim(block_in);
   arma::mat mat(m, n, arma::fill::zeros); // zeroed here; kernel uses +=
@@ -137,6 +141,8 @@ XDIAG_CATCH
 template <typename op_t>
 arma::cx_mat matrixC(op_t const &op, Block const &block_in,
                      Block const &block_out) try {
+  check_blocks_match(OpSum(op), block_in, block_out);
+
   int64_t m = size(block_out);
   int64_t n = dim(block_in);
   arma::cx_mat mat(m, n, arma::fill::zeros); // zeroed here; kernel uses +=

--- a/xdiag/kernels/sparse/valid.cpp
+++ b/xdiag/kernels/sparse/valid.cpp
@@ -25,12 +25,7 @@ void check_valid_sparse_matrix(OpSum const &ops, Block const &block_in,
   }
 
   // Check if ops and blocks are compatible
-  if (!blocks_match(ops, block_in, block_out)) {
-    XDIAG_THROW("Cannot create a sparse matrix on blocks. The resulting block "
-                "is not in "
-                "the correct symmetry sector. Please check the quantum numbers "
-                "of the output block.");
-  }
+  check_blocks_match(ops, block_in, block_out);
 
   // Check if real matrix can be created
   if constexpr (isreal<coeff_t>()) {

--- a/xdiag/states/apply.cpp
+++ b/xdiag/states/apply.cpp
@@ -56,12 +56,7 @@ void apply(OpSum const &ops, State const &v, State &w) try {
     w = State();
   } else {
 
-    if (!blocks_match(ops, v.block(), w.block())) {
-      XDIAG_THROW(
-          "Cannot apply OpSum to State. The resulting state is not in "
-          "the correct symmetry sector. Please check the quantum numbers "
-          "of the output state w.");
-    }
+    check_blocks_match(ops, v.block(), w.block());
 
     if ((v.ncols() == 1) && (w.ncols() == 1)) {
       if (isreal(ops)) {


### PR DESCRIPTION
fixes discussion #110, an error should have been thrown, due to a wrong user input, but the required checks were performed at too high level.